### PR TITLE
Add missed ts defenitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "build/react-hookedup.js",
   "umd:main": "build/react-hookedup.umd.js",
   "module": "build/react-hookedup.m.js",
+  "types": "build/src/index.d.ts",
   "source": "src/index.ts",
   "repository": "https://github.com/zakariaharti/react-hookedup.git",
   "author": "zakaria harti <zakariya.harti@gmail.com> (https://github.com/zakariaharti)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
-    "declaration": false,
+    "declaration": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "typeRoots": [


### PR DESCRIPTION
In final build `types.d.ts` are missed which makes it impossible to use in `typescript` project where `node_modules` are typically excluded from `ts-loader`